### PR TITLE
Adding the notion of patch type

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ As you can see, we are installing two packages here.
 - **mouf/utils.patcher** contains the patch service. The patch service can be used to install any kinds of patches, but does not contain any patches implementation. This is why we need the second packages.
 - **mouf/database.patcher** adds an easy way to create database patches (the most common use of the patch system).
 
-Using the patch service
------------------------
+Using the patch service (graphical user interface)
+--------------------------------------------------
 
 Once the patch service is installed, you will notice there is a new menu in Mouf UI.
 
@@ -54,6 +54,28 @@ features like database replication, etc...
 If you need a more *fine-tuned* approach, you can **apply** each patch one by one. You can also 
 **skip** the patch if you prefer to run it yourself or if you know it has already been applied.
 Finally, you will notice that some patches can be **reverted**.
+
+Using the patch service (command line interface)
+------------------------------------------------
+
+You can also apply patches using the Mouf console. This is especially useful for deployments in continuous integration environments or on a production server.
+
+```sh
+$ # Apply all default patches
+$ vendor/bin/mouf_console patches:apply-all
+$
+$ # Apply all patches from type default AND test_data
+$ vendor/bin/mouf_console patches:apply-all --test-data
+$
+$ # View a list of all patches
+$ vendor/bin/mouf_console patches:list
+$
+$ # Apply one specific patch by name
+$ vendor/bin/mouf_console patches:apply [patch_name]
+$
+$ # Revert one specific patch by name
+$ vendor/bin/mouf_console patches:revert [patch_name]
+```
 
 
 Creating/Editing a database patch
@@ -74,13 +96,23 @@ In this case, you should **skip** the patch (there is no point in applying this 
 - If you haven't applied the patch yet, you can choose to save and **apply** the patch.
 - Finally, you can also choose to save, but **do not apply** the patch yet. In this case, the patch will be in **Awating** state. 
  
-###Advanced options
+### Advanced options
 
 There are a number of advanced options. These will allow you to:
 
 - Choose the file saving the patch (the SQL of the patch is stored in its own file, usually in the **database/up** directory.
 - Set up a *reverse patch* that can be used to cancel/revert your patch.
 
+### Patch type
+
+When creating a database patch, you can select a patch "type".
+
+By default, the package comes with 2 bundled types:
+
+- *default*: for patches that should always be applied (like patches modifying the database model)
+- *test_data*: for patches that should be applied conditionnally based on the environment (you might want test data in your development environment but not in production)
+
+You can also edit thos patch types or add your own patch types by editing the `patchService` instance in Mouf.
 
 [You are a package developer? You want your own package to create/modify tables? See how you can use the patch system for that.](doc/for_packages_developer.md)  
 [Want to learn more about the patch system? Want to learn how to create you own non db-related patches? Have a look at the advanced documentation.](doc/advanced.md)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-    	"php": ">=5.5.0",
+    	"php": ">=7.0",
     	"mouf/mouf-validators-interface": "~2.0",
 	    "mouf/utils.console": "~1.0"
     },
@@ -26,7 +26,7 @@
 	     "mouf": {
 		    "install" : [{
 			    "type" : "class",
-			    "class" : "Mouf\\Utils\\Patcher\\PatchInstaller",
+			    "class" : "Mouf\\Utils\\Patcher\\PatchInstaller2",
 			    "description": "Create the patchService instance."
 			}
 		    ],

--- a/src/Mouf/Utils/Patcher/Commands/ApplyAllPatchesCommand.php
+++ b/src/Mouf/Utils/Patcher/Commands/ApplyAllPatchesCommand.php
@@ -22,8 +22,8 @@ class ApplyAllPatchesCommand extends Command
 
     public function __construct(PatchService $patchService)
     {
-        parent::__construct();
         $this->patchService = $patchService;
+        parent::__construct();
     }
 
 
@@ -34,16 +34,22 @@ class ApplyAllPatchesCommand extends Command
     {
         $this
         ->setName('patches:apply-all')
-        ->setDescription('Apply all pending patches.')
+        ->setDescription('Apply pending patches.')
         ->setDefinition(array(
 
         ))
         ->setHelp(<<<EOT
-Apply all pending patches.
+Apply pending patches. You can select the type of patches to be applied using the options. Default patches are always applied.
 
 Use patches:apply if you want to cherry-pick a particular patch.
 EOT
         );
+
+        foreach ($this->patchService->getTypes() as $type) {
+            if ($type->getName() !== '') {
+                $this->addOption($type->getName(), null, InputOption::VALUE_NONE, 'Applies patches of type "'.$type->getName().'". '.$type->getDescription());
+            }
+        }
     }
 
     /**

--- a/src/Mouf/Utils/Patcher/Commands/ListPatchesCommand.php
+++ b/src/Mouf/Utils/Patcher/Commands/ListPatchesCommand.php
@@ -54,12 +54,12 @@ EOT
         $patches = $this->patchService->getView();
 
         $rows = array_map(function($row) {
-            return [ $row['uniqueName'], $this->renderStatus($row['status']) ];
+            return [ $row['uniqueName'], $this->renderStatus($row['status']), $row['patch_type'] ?: '(default)' ];
         }, $patches);
 
         $table = new Table($output);
         $table
-            ->setHeaders(array('Patch', 'Status'))
+            ->setHeaders(array('Patch', 'Status', 'Type'))
             ->setRows($rows)
         ;
         $table->render();

--- a/src/Mouf/Utils/Patcher/PatchInstaller2.php
+++ b/src/Mouf/Utils/Patcher/PatchInstaller2.php
@@ -8,6 +8,7 @@ namespace Mouf\Utils\Patcher;
 
 use Mouf\Actions\InstallUtils;
 use Mouf\Console\ConsoleUtils;
+use Mouf\Database\Patcher\PatchConnection;
 use Mouf\Installer\PackageInstallerInterface;
 use Mouf\MoufManager;
 use Mouf\Utils\Patcher\Commands\ApplyAllPatchesCommand;

--- a/src/Mouf/Utils/Patcher/PatchInstaller2.php
+++ b/src/Mouf/Utils/Patcher/PatchInstaller2.php
@@ -16,7 +16,7 @@ use Mouf\Utils\Patcher\Commands\ListPatchesCommand;
 use Mouf\Utils\Patcher\Commands\RevertPatchCommand;
 use Mouf\Utils\Patcher\Commands\SkipPatchCommand;
 
-class PatchInstaller implements PackageInstallerInterface
+class PatchInstaller2 implements PackageInstallerInterface
 {
     /**
      * (non-PHPdoc)
@@ -27,7 +27,19 @@ class PatchInstaller implements PackageInstallerInterface
     public static function install(MoufManager $moufManager)
     {
         // Let's create the instance.
-        $patchService = InstallUtils::getOrCreateInstance('patchService', 'Mouf\\Utils\\Patcher\\PatchService', $moufManager);
+        $patchDefaultType = InstallUtils::getOrCreateInstance('patch.default_type', PatchType::class, $moufManager);
+        $patchDefaultType->getConstructorArgumentProperty('name')->setValue('');
+        $patchDefaultType->getConstructorArgumentProperty('description')->setValue('Patches that should be always applied should have this type. Typically, use this type for DDL changes or reference data insertion.');
+
+        $patchTestDataType = InstallUtils::getOrCreateInstance('patch.testdata_type', PatchType::class, $moufManager);
+        $patchTestDataType->getConstructorArgumentProperty('name')->setValue('test_data');
+        $patchTestDataType->getConstructorArgumentProperty('description')->setValue('Use this type to mark patches that contain test data that should only be used in staging environment.');
+
+        $patchService = InstallUtils::getOrCreateInstance('patchService', PatchService::class, $moufManager);
+
+        if (empty($patchService->getConstructorArgumentProperty('types')->getValue())) {
+            $patchService->getConstructorArgumentProperty('types')->setValue([ $patchDefaultType, $patchTestDataType ]);
+        }
 
         $consoleUtils = new ConsoleUtils($moufManager);
 

--- a/src/Mouf/Utils/Patcher/PatchInterface.php
+++ b/src/Mouf/Utils/Patcher/PatchInterface.php
@@ -34,25 +34,25 @@ interface PatchInterface {
 	/**
 	 * Applies the patch.
 	 */
-	public function apply();
+	public function apply(): void;
 	
 	/**
 	 * Skips the patch (sets its status to "skipped").
 	 */
-    public function skip();
+    public function skip(): void;
 
 	/**
 	 * Reverts (cancels) the patch.
 	 * Note: patchs do not have to provide a "revert" feature (see canRevert method).
 	 */
-    public function revert();
+    public function revert(): void;
 	
 	/**
 	 * Returns true if this patch can be canceled, false otherwise.
 	 * 
 	 * @return boolean
 	 */
-    public function canRevert();
+    public function canRevert(): bool;
 	
 	/**
 	 * Returns the status of this patch.
@@ -65,28 +65,28 @@ interface PatchInterface {
 	 * 
 	 * @return string
 	 */
-    public function getStatus();
+    public function getStatus(): string;
 	
 	/**
 	 * Returns a unique name for this patch. 
 	 *
 	 * @return string
 	 */
-    public function getUniqueName();
+    public function getUniqueName(): string;
 	
 	/**
 	 * Returns a short description of the patch.
 	 * 
 	 * @return string
 	 */
-    public function getDescription();
+    public function getDescription(): string;
 	
 	/**
 	 * Returns the error message of the last action performed, or null if last action was successful.
 	 * 
 	 * @return string
 	 */
-    public function getLastErrorMessage();
+    public function getLastErrorMessage(): ?string;
 	
 	/**
 	 * Returns the URL that can be used to edit this patch.
@@ -94,7 +94,7 @@ interface PatchInterface {
 	 * 
 	 * @return string
 	 */
-    public function getEditUrl();
+    public function getEditUrl(): string;
 
     /**
      * Returns the type of the patch.

--- a/src/Mouf/Utils/Patcher/PatchInterface.php
+++ b/src/Mouf/Utils/Patcher/PatchInterface.php
@@ -26,33 +26,33 @@ namespace Mouf\Utils\Patcher;
  */
 interface PatchInterface {
 
-	const STATUS_AWAITING = "awaiting";
-	const STATUS_APPLIED = "applied";
-	const STATUS_SKIPPED = "skipped";
-	const STATUS_ERROR = "error";
+	const STATUS_AWAITING = 'awaiting';
+	const STATUS_APPLIED = 'applied';
+	const STATUS_SKIPPED = 'skipped';
+	const STATUS_ERROR = 'error';
 	
 	/**
 	 * Applies the patch.
 	 */
-	function apply();
+	public function apply();
 	
 	/**
 	 * Skips the patch (sets its status to "skipped").
 	 */
-	function skip();
+    public function skip();
 
 	/**
 	 * Reverts (cancels) the patch.
 	 * Note: patchs do not have to provide a "revert" feature (see canRevert method).
 	 */
-	function revert();
+    public function revert();
 	
 	/**
 	 * Returns true if this patch can be canceled, false otherwise.
 	 * 
 	 * @return boolean
 	 */
-	function canRevert();
+    public function canRevert();
 	
 	/**
 	 * Returns the status of this patch.
@@ -65,28 +65,28 @@ interface PatchInterface {
 	 * 
 	 * @return string
 	 */
-	function getStatus();
+    public function getStatus();
 	
 	/**
 	 * Returns a unique name for this patch. 
 	 *
 	 * @return string
 	 */
-	function getUniqueName();
+    public function getUniqueName();
 	
 	/**
 	 * Returns a short description of the patch.
 	 * 
 	 * @return string
 	 */
-	function getDescription();
+    public function getDescription();
 	
 	/**
 	 * Returns the error message of the last action performed, or null if last action was successful.
 	 * 
 	 * @return string
 	 */
-	function getLastErrorMessage();
+    public function getLastErrorMessage();
 	
 	/**
 	 * Returns the URL that can be used to edit this patch.
@@ -94,6 +94,12 @@ interface PatchInterface {
 	 * 
 	 * @return string
 	 */
-	function getEditUrl();
-}
+    public function getEditUrl();
 
+    /**
+     * Returns the type of the patch.
+     *
+     * @return PatchType
+     */
+    public function getPatchType() : PatchType;
+}

--- a/src/Mouf/Utils/Patcher/PatchService.php
+++ b/src/Mouf/Utils/Patcher/PatchService.php
@@ -76,6 +76,17 @@ class PatchService implements MoufValidatorInterface {
         return $this->types;
     }
 
+    /**
+     * @internal Returns a serialized list of types for the patch UI.
+     * @return array
+     */
+    public function _getSerializedTypes(): array
+    {
+        return array_map(function(PatchType $type) {
+            return $type->jsonSerialize();
+        }, $this->types);
+    }
+
 	/**
 	 * Adds this patch to the list of existing patches.
 	 * If the patch already exists, an exception is thrown.
@@ -203,6 +214,8 @@ class PatchService implements MoufValidatorInterface {
 	
 	/**
 	 * Returns a PHP array representing the patchs.
+     *
+     * @internal
 	 */
 	public function getView(): array {
 		$view = array();

--- a/src/Mouf/Utils/Patcher/PatchType.php
+++ b/src/Mouf/Utils/Patcher/PatchType.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Mouf\Utils\Patcher;
+
+
+class PatchType
+{
+    /**
+     * @var string
+     */
+    private $name;
+    /**
+     * @var string
+     */
+    private $description;
+
+    /**
+     * @param string $name The name of the patch type. Should not contain special characters or spaces. Note: the default type is an empty string.
+     * @param string $description The description of the patch type
+     * @throws PatchException
+     */
+    public function __construct(string $name, string $description)
+    {
+        if (!preg_match('/[^a-z_\-0-9]/i', $name)) {
+            throw new PatchException('A patch name can only contain alphanumeric characters and underscore.');
+        }
+
+        $this->name = $name;
+        $this->description = $description;
+    }
+
+    /**
+     * The name of the patch type. Should not contain special characters or spaces.
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * The description of the patch type.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+}

--- a/src/Mouf/Utils/Patcher/PatchType.php
+++ b/src/Mouf/Utils/Patcher/PatchType.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 namespace Mouf\Utils\Patcher;
 
 
-class PatchType
+use Mouf\MoufManager;
+
+class PatchType implements \JsonSerializable
 {
     /**
      * @var string
@@ -16,14 +18,15 @@ class PatchType
     private $description;
 
     /**
+     * @Important
      * @param string $name The name of the patch type. Should not contain special characters or spaces. Note: the default type is an empty string.
      * @param string $description The description of the patch type
      * @throws PatchException
      */
     public function __construct(string $name, string $description)
     {
-        if (!preg_match('/[^a-z_\-0-9]/i', $name)) {
-            throw new PatchException('A patch name can only contain alphanumeric characters and underscore.');
+        if (!preg_match('/^[a-z_\-0-9]*$/i', $name)) {
+            throw new PatchException('A patch name can only contain alphanumeric characters and underscore. Name passed: "'.$name.'"');
         }
 
         $this->name = $name;
@@ -48,5 +51,21 @@ class PatchType
     public function getDescription(): string
     {
         return $this->description;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'instanceName' => MoufManager::getMoufManager()->findInstanceName($this)
+        ];
     }
 }

--- a/src/views/applyPatches.php
+++ b/src/views/applyPatches.php
@@ -1,0 +1,15 @@
+<?php use Mouf\Utils\Patcher\PatchInterface;
+/* @var $this Mouf\Utils\Patcher\Controllers\PatchController */ ?>
+<h1>Apply patches</h1>
+
+Please select the patch types you want to apply:
+
+<form action="applyAllPatches" method="post">
+    <input name="name" type="hidden" value="<?php echo plainstring_to_htmlprotected($this->instanceName); ?>"></input>
+    <input name="selfedit" type="hidden" value="<?php echo plainstring_to_htmlprotected($this->selfedit); ?>"></input>
+<?php foreach ($this->nbPatchesByType as $name => $number): ?>
+    <label class="checkbox"><input type="checkbox" name="types[]" value="<?= plainstring_to_htmlprotected($name) ?>" <?php if ($name == '') { echo "checked readonly"; } ?> /> <?= plainstring_to_htmlprotected($name?:'default') ?> (<?= $number ?> patch<?= $number > 1 ? 'es':'' ?>)</label>
+<?php endforeach; ?>
+
+    <button class="btn btn-large btn-success"><i class="icon-arrow-right icon-white"></i> Apply selected patches</button>
+</form>

--- a/src/views/patchesList.php
+++ b/src/views/patchesList.php
@@ -37,7 +37,8 @@ if ($this->nbAwaiting == 0 && $this->nbError == 0) {
 	<tr>
 		<th style="width:10%">Status</th>
 		<th style="width:20%">Name</th>
-		<th style="width:40%">Description</th>
+		<th style="width:30%">Description</th>
+        <th style="width:10%">Type</th>
 		<th style="width:30%">Actions</th>
 	</tr>
 <?php 
@@ -63,6 +64,7 @@ foreach ($this->patchesArray as $patch): ?>
 		</td>
 		<td><?php echo plainstring_to_htmlprotected($patch['uniqueName']) ?></td>
 		<td><?php echo plainstring_to_htmlprotected($patch['description']) ?></td>
+        <td><?php echo $patch['patch_type'] ? plainstring_to_htmlprotected($patch['patch_type']) : '<i>(default)</i>' ?></td>
 		<td>
 		<?php 
 		


### PR DESCRIPTION
Patches now have a "type".
By default, the package comes with 2 prepackages types: "default" (for normal patches) and "test_data" (for patches that contain test data that should not be deployed to production systems.

When creating a patch, the user now selects the patch type.
When applying patches, the user is asked which patch types he should apply.

Command line command is also impacted with the addition of special options (one per patch type) in the "apply-all" command.

Since this modifies the PatchInterface, this is a breaking change and justifies the fact to tag a 2.0 release.